### PR TITLE
Reflect play state to play-bar-button

### DIFF
--- a/src/components/Album.vue
+++ b/src/components/Album.vue
@@ -92,6 +92,7 @@
           index: index,
           list: list
         })
+        this.$store.commit('play', true)
       },
       showMenu: function (num) {
         this.menus = {

--- a/src/components/RankPage.vue
+++ b/src/components/RankPage.vue
@@ -85,6 +85,7 @@
           index: index,
           list: list
         })
+        this.$store.commit('play', true)
       },
       showMenu: function (num) {
         this.menus = {

--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -161,6 +161,7 @@
           index: index,
           list: this.searchRes.song.itemlist
         })
+        this.$store.commit('play', true)
       },
       showMenu: function (num) {
         this.menus = {

--- a/src/components/Singer.vue
+++ b/src/components/Singer.vue
@@ -98,6 +98,7 @@
           index: index,
           list: list
         })
+        this.$store.commit('play', true)
       },
       showMenu: function (num) {
         this.menus = {


### PR DESCRIPTION
Hi there, I stumbled upon this demo project via http://vuejsexamples.com/ and really admire the elegant design & implementation. 

I just noticed a minor bug where the play state is not being reflected to the `.play-bar-button` element when you play a song from either `Album.vue`, `Rankpage.vue`, `Search.vue` and `Singer.vue`. Just thought it would provide trivially better experience if the play state is reflected to the buttom button, hope this fix is ok.

### before

<img src="https://cloud.githubusercontent.com/assets/1957801/20639671/2c51a876-b40d-11e6-85ea-5cdd313637ec.gif" width="250">

### after

<img src="https://cloud.githubusercontent.com/assets/1957801/20639672/2c51fc04-b40d-11e6-8fe0-28a7e01a4551.gif" width="250">