### PR TITLE
vue.util.isObject is not a function fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "rxjs": "^5.0.2",
     "vue": "^2.0.1",
     "vue-awesome-swiper": "^2.2.6",
-    "vue-lazyload": "^1.0.0-rc7",
+    "vue-lazyload": "1.0.0-rc12",
     "vue-resource": "^1.0.3",
     "vue-router": "^2.1.1",
     "vuex": "^2.0.0"


### PR DESCRIPTION
在vue2.2.0的版本之后弃用了util.isObject(object)，vue-lazyload在1.0.0-rc12修复了这个问题